### PR TITLE
Update homepage with logo and color scheme

### DIFF
--- a/v56-team22-surgery-status-board/src/components/Home/HomeCard.tsx
+++ b/v56-team22-surgery-status-board/src/components/Home/HomeCard.tsx
@@ -1,0 +1,43 @@
+import { Link } from 'react-router';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { SecondaryLogo } from '@/components/Logos';
+
+const HomeCard = () => {
+  return (
+      <Card className="w-full max-w-2xl bg-primary shadow-lg">
+        <CardHeader className="text-center">
+          <SecondaryLogo className="w-52 mx-auto"/>
+        </CardHeader>
+        <CardContent className="bg-primary text-justify text-white px-15">
+          <p className="text-lg mb-[30px]">
+            Welcome to MediPhase, your guide to monitoring patient and loved ones during their surgery journey. With real-time updates, MediPhase provides
+            real-time updates on patient status. <br />
+          </p>
+          <p className="text-lg mb-[30px]">
+            You stay informed every step of the way. Simple, secure, and
+            compassionate care at your fingertips.
+          </p>
+          <div className="flex flex-col gap-[30px] justify-around md:flex-row items-center">
+            <Link to={'/sign-in'} className="w-full md:w-1/2">
+              <Button
+                variant="outline"
+                className="w-full font-bold text-primary cursor-pointer hover:scale-105 transition-transform"
+              >
+                Admin Sign In
+              </Button>
+            </Link>
+            <Link to={'/patient-status'} className="w-full md:w-1/2">
+              <Button
+                variant="outline"
+                className="w-full font-bold text-primary cursor-pointer hover:scale-105 transition-transform">
+                Guest
+              </Button>
+            </Link>
+          </div>
+        </CardContent>
+      </Card>
+  );
+};
+
+export default HomeCard;

--- a/v56-team22-surgery-status-board/src/layout/MainLayout.tsx
+++ b/v56-team22-surgery-status-board/src/layout/MainLayout.tsx
@@ -9,7 +9,7 @@ const MainLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   return (
     <div className="flex flex-col h-screen w-full">
       <Header role={user?.role || "guest"} />
-      <main className="flex-1">{children}</main>
+      <main className="flex-1 py-8">{children}</main>
       <Footer />
     </div>
   );

--- a/v56-team22-surgery-status-board/src/screens/Home.tsx
+++ b/v56-team22-surgery-status-board/src/screens/Home.tsx
@@ -1,40 +1,10 @@
-import { Link } from 'react-router';
-import { Button } from '@/components/ui/button';
+import HomeCard from '@/components/Home/HomeCard';
 
 const Home = () => {
   return (
-    <div className="px-[30px] md:px-[100px] mt-[100px] flex flex-col justify-center items-center">
-      <h1 className="text-4xl font-bold text-center mb-[60px]">
-        Welcome to MediPhase
-      </h1>
-      <p className="text-lg text-center mb-[30px]">
-        Monitor your loved ones' surgery journey with ease. MediPhase provides
-        real-time updates on patient status—Checked In, Pre-Procedure, In
-        Progress, Closing, Recovery, Complete and Dismissed <br />
-      </p>
-      <p className="text-lg text-center mb-[100px]">
-        You stay informed every step of the way. Simple, secure, and
-        compassionate care at your fingertips.
-      </p>
-
-      <div className="flex flex-col gap-[30px] justify-center md:flex-row md:gap-[100px] mb-[100px]">
-        <Link to={'/sign-in'}>
-          <Button
-            variant="default"
-            className="w-[185px] h-[68px] rounded-xl bg-[#32AA2A] text-white"
-          >
-            Sign in
-          </Button>
-        </Link>
-        <Link to={'/patient-status'}>
-          <Button
-            variant="default"
-            className="w-[185px] h-[68px] rounded-xl bg-[#32AA2A] text-white"
-          >
-            Sign in as guest
-          </Button>
-        </Link>
-      </div>
+    <div className="flex flex-col justify-between items-center">
+      {/* Main content area */}
+      <HomeCard />
     </div>
   );
 };


### PR DESCRIPTION
To tidy up the home page, I've

- added a card with the mediphase logo
- updated the buttons to feel a bit more interactive
- provided the `mainlayout` with padding so items can be easily placed 

<img width="1587" height="558" alt="Screenshot 2025-08-19 at 09 49 22" src="https://github.com/user-attachments/assets/dbce4eab-1ec8-498c-aa69-31652c42ba98" />
